### PR TITLE
Fix the g:github_complete_ghe_host documentation

### DIFF
--- a/doc/github-complete.txt
+++ b/doc/github-complete.txt
@@ -314,8 +314,12 @@ g:github_complete_github_api_token          *g:github_complete_github_api_token*
 g:github_complete_ghe_host                          *g:github_complete_ghe_host*
 
     If you're a user of Github Enterprise, set this variable to your host.
-    Default value is "github.com".
+    Default value is "".
 
+    e.g.
+>
+    let g:github_complete_ghe_host = 'github.mycompany.io'
+<
 ==============================================================================
 MAPPINGS                                          *github-complete.vim-mappings*
 


### PR DESCRIPTION
- The default value is ""

- Add an example to be clearer for this plugin's users